### PR TITLE
Set title colors programatically

### DIFF
--- a/FocusTvButton/Source/FocusTvButton.swift
+++ b/FocusTvButton/Source/FocusTvButton.swift
@@ -30,8 +30,16 @@ public class FocusTvButton: UIButton {
     @IBInspectable public var shadowColor: CGColor = UIColor.black.cgColor
     @IBInspectable public var shadowOffSetFocused: CGSize = CGSize(width: 0, height: 27)
     @IBInspectable public var animationDuration: TimeInterval = 0.2
-    @IBInspectable public var focusedTitleColor: UIColor = .white
-    @IBInspectable public var normalTitleColor: UIColor = .white
+    @IBInspectable public var focusedTitleColor: UIColor = .white {
+        didSet {
+            setTitleColor(focusedTitleColor, for: .focused)
+        }
+    }
+    @IBInspectable public var normalTitleColor: UIColor = .white {
+        didSet {
+            setTitleColor(normalTitleColor, for: .normal)
+        }
+    }
     @IBInspectable public var gradientStartPoint: CGPoint = .zero
     @IBInspectable public var gradientEndPoint: CGPoint = CGPoint(x: 1, y: 1)
     


### PR DESCRIPTION
Hello sir, the title colors work great when initialized via Interface Builder but when setting the colors in code the text remains white.

I added `didSet` to set the text label colors for the focus and normal colors.